### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/lib/medium-upload-view.js
+++ b/lib/medium-upload-view.js
@@ -101,9 +101,9 @@ export default class MediumUploadView {
     message.html(state);
   }
 
-  attachHandlers (package) {
-    $('.medium-public-btn').on('click', () => package.public());
-    $('.medium-draft-btn').on('click', () => package.draft());
+  attachHandlers (pack) {
+    $('.medium-public-btn').on('click', () => pack.public());
+    $('.medium-draft-btn').on('click', () => pack.draft());
   }
 
 }


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!